### PR TITLE
Remove rake < 11 dependency for railties

### DIFF
--- a/railties/railties.gemspec
+++ b/railties/railties.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.executables = ['rails']
   s.rdoc_options = ['--exclude', '.']
 
-  s.add_dependency 'rake',           '>= 0.8.3', '< 11'
+  s.add_dependency 'rake',           '>= 0.8.3'
   s.add_dependency 'activesupport',  "= #{RailsLts::VERSION::STRING}"
   s.add_dependency 'actionpack',     "= #{RailsLts::VERSION::STRING}"
 end


### PR DESCRIPTION
rake < 11 was done to support ruby 1.8.7. 
Ruby 1.8.7 users can specify in their Gemfile the lower dependency.
This way users with higher versions of ruby can use newer rake versions.